### PR TITLE
Add HTTPS to the listener protocols

### DIFF
--- a/neutron_lbaas_dashboard/static/dashboard/project/lbaasv2/workflow/listener/listener.controller.js
+++ b/neutron_lbaas_dashboard/static/dashboard/project/lbaasv2/workflow/listener/listener.controller.js
@@ -48,7 +48,7 @@
     ////////////
 
     function protocolChange(protocol) {
-      var defaultPort = { HTTP: 80, TERMINATED_HTTPS: 443 }[protocol];
+      var defaultPort = { HTTP: 80, TERMINATED_HTTPS: 443, HTTPS: 443 }[protocol];
       while (listenerPortExists(defaultPort)) {
         defaultPort += 1;
       }
@@ -56,7 +56,7 @@
 
       var members = $scope.model.members.concat($scope.model.spec.members);
       members.forEach(function setMemberPort(member) {
-        member.port = { HTTP: 80, TERMINATED_HTTPS: 80 }[protocol];
+        member.port = { HTTP: 80, TERMINATED_HTTPS: 80, HTTPS: 443 }[protocol];
       });
 
       var workflow = $scope.workflow;

--- a/neutron_lbaas_dashboard/static/dashboard/project/lbaasv2/workflow/model.service.js
+++ b/neutron_lbaas_dashboard/static/dashboard/project/lbaasv2/workflow/model.service.js
@@ -85,7 +85,7 @@
       visibleResources: [],
       subnets: [],
       members: [],
-      listenerProtocols: ['HTTP', 'TCP', 'TERMINATED_HTTPS'],
+      listenerProtocols: ['HTTP', 'TCP', 'TERMINATED_HTTPS', 'HTTPS'],
       methods: ['LEAST_CONNECTIONS', 'ROUND_ROBIN', 'SOURCE_IP'],
       monitorTypes: ['HTTP', 'PING', 'TCP'],
       monitorMethods: ['GET', 'HEAD'],

--- a/neutron_lbaas_dashboard/static/dashboard/project/lbaasv2/workflow/model.service.spec.js
+++ b/neutron_lbaas_dashboard/static/dashboard/project/lbaasv2/workflow/model.service.spec.js
@@ -333,7 +333,7 @@
       });
 
       it('has array of listener protocols', function() {
-        expect(model.listenerProtocols).toEqual(['HTTP', 'TCP', 'TERMINATED_HTTPS']);
+        expect(model.listenerProtocols).toEqual(['HTTP', 'TCP', 'TERMINATED_HTTPS', 'HTTPS']);
       });
 
       it('has array of pool methods', function() {


### PR DESCRIPTION
Due to bug in Barbican, only admin tenant is able to use TERMINATED_HTTPS.
Users from other tenants should use own certificates placed on nodes instead.
CLI tools (and examples in official docs) supports "HTTPS" as listener protocol, but lbaas-dashaboard does not have such option on the dropdown list.
This commit adds needed function.

